### PR TITLE
make unawaited a generic function

### DIFF
--- a/lib/pedantic.dart
+++ b/lib/pedantic.dart
@@ -22,4 +22,4 @@ import 'dart:async' show Future;
 ///   unawaited(log('Preferences saved!'));
 /// }
 /// ```
-void unawaited(Future<void>? future) {}
+void unawaited<T>(Future<T>? future) {}


### PR DESCRIPTION
I just recently hit a snag using `unawaited` that I believe could have been avoided were it generic.

Thoughts? Reservations?

/cc @davidmorgan @bwilkerson 