### PR TITLE
stable null safety release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.0
+
+* Stable null safety release.
+
 ## 1.10.0-nullsafety.3
 
 * Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pedantic
-version: 1.10.0-nullsafety.3
+version: 1.10.0
 description: >-
   The Dart analyzer settings and best practices used internally at Google.
 homepage: https://github.com/google/pedantic


### PR DESCRIPTION
This is now ready for release and will unblock publishing stable versions of other packages that depend on it.